### PR TITLE
Add doc in to created archive

### DIFF
--- a/1N_2018/validation/run_validate_1N.sh
+++ b/1N_2018/validation/run_validate_1N.sh
@@ -86,7 +86,7 @@ echo "[SUCCESS]"
 echo -n "Creating submission package "
 libstring=$(basename `ls ./lib/libfrvt1N_*_?.so`)
 libstring=${libstring%.so}
-tar -zcf $libstring.tar.gz ./config ./lib ./validation
+tar -zcf $libstring.tar.gz ./doc ./config ./lib ./validation
 echo "[SUCCESS]"
 echo "
 #################################################################################################################


### PR DESCRIPTION
According to Page 7 of API v1.0 (Released here: https://www.nist.gov/sites/default/files/documents/2017/11/20/frvt_1n_api_v1.0.pdf), we should have a doc directory contained in our archive.

> doc/ - contains version.txt, which documents versioning information for the submitted software and any other provided documentation regarding the submission