### PR TITLE
Fix OS version comparsion in 11/run_validate_11.sh

### DIFF
--- a/11/run_validate_11.sh
+++ b/11/run_validate_11.sh
@@ -8,7 +8,7 @@ normal=$(tput sgr0)
 # Check version of OS
 reqOS="CentOS Linux release 7.6.1810 (Core)"
 currentOS=$(cat /etc/centos-release)
-if [ $reqOS != $currentOS ]; then
+if [ "$reqOS" != "$currentOS" ]; then
 	echo "${bold}[ERROR] You are not running the correct version of the operating system, which should be $reqOS.  Please install the correct operating system and re-run this validation package.${normal}"
 	exit $failure
 fi


### PR DESCRIPTION
When $reqOS or $currentOS contains spaces IF operator will not work without quotes around variables.
if [ "$reqOS" != "$currentOS" ]; then

example: 
[root@123 src]# if [ 1 2 != 3 4 ]; then echo 123; fi
bash: [: too many arguments