### PR TITLE
Add bc package to necessary pkgs for 11validation

### DIFF
--- a/11/run_validate_11.sh
+++ b/11/run_validate_11.sh
@@ -15,7 +15,7 @@ fi
 
 # Install the necessary packages to run validation
 echo -n "Checking installation of required packages "
-for package in coreutils gawk gcc gcc-c++ grep cmake sed
+for package in coreutils gawk gcc gcc-c++ grep cmake sed bc 
 do
 	yum -q list installed $package &> /dev/null
 	retcode=$?


### PR DESCRIPTION
In 11/run_validate_11.sh:72 program bc is used. We should add it to required packages.