### PR TITLE
Fix imprecise storage size.

### DIFF
--- a/11/src/nullImpl/nullimplfrvt11.cpp
+++ b/11/src/nullImpl/nullimplfrvt11.cpp
@@ -38,7 +38,7 @@ NullImplFRVT11::createTemplate(
     std::vector<float> fv = {1.0, 2.0, 8.88, 765.88989};
     const uint8_t* bytes = reinterpret_cast<const uint8_t*>(fv.data());
     int dataSize = sizeof(float) * fv.size();
-    templ.resize(dataSize);
+    templ.resize(dataSize / sizeof(uint8_t));
     memcpy(templ.data(), bytes, dataSize);
 
     for (unsigned int i=0; i<faces.size(); i++) {


### PR DESCRIPTION
According to official Documents:
> C++11
void resize (size_type n);
void resize (size_type n, const value_type& val);
Change size
Resizes the container so that it contains **n elements**.