### PR TITLE
Update enroll_multiface.txt

### DIFF
--- a/11/input/enroll_multiface.txt
+++ b/11/input/enroll_multiface.txt
@@ -1,5 +1,5 @@
 1 ../common/images/face/S001-01-t10_01.ppm faceunknown ../common/images/face/S001-03-t10_01.ppm faceunknown ../common/images/face/S001-05-t10_01.ppm faceunknown ../common/images/face/S001-07-t10_01.ppm faceunknown ../common/images/face/S001-08-t10_02.ppm faceunknown ../common/images/face/S001-09-t10_01.ppm faceunknown
-21 ../common/images/face/S008-02-t10_01.ppm faceunknown ../common/images/face/S008-04-t10_01.ppm faceunknown ../common/images/face/S008-06-t10_01.ppm
+21 ../common/images/face/S008-02-t10_01.ppm faceunknown ../common/images/face/S008-04-t10_01.ppm faceunknown ../common/images/face/S008-06-t10_01.ppm faceunknown 
 45 ../common/images/face/S023-01-t10_01.ppm faceunknown ../common/images/face/S023-03-t10_01.ppm faceunknown
 59 ../common/images/face/S030-01-t10_01.ppm faceunknown ../common/images/face/S030-03-t10_01.ppm faceunknown ../common/images/face/S030-05-t10_01.ppm faceunknown
 65 ../common/images/face/S031-02-t10_01.ppm faceunknown ../common/images/face/S031-04-t10_01.ppm faceunknown ../common/images/face/S031-06-t10_01.ppm faceunknown


### PR DESCRIPTION
Modified line 2 to include the image description

On a closer look at the validation code [here](https://github.com/usnistgov/frvt/blob/14e01d37f4fd34ceedd3fef86585695369d79694/11/src/testdriver/validate11.cpp#L79) we can see that for line 2 of `enroll_multiface.txt`, only first two images will be considered for creation of the template since

```
tokens.size() = 5

auto numImages = (tokens.size() - 1)/2;
i.e. numImages = (5 - 1)/2
i.e. numImages = 2
```

Adding description as the final token in the second line solves this problem and we get the expected template.

Thanks!